### PR TITLE
fix(style): update font size syntax for h1 on homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,15 +8,15 @@ changeLanguage("en");
 const title = "Susu";
 const description = "Susu";
 const meta = {
-    title,
-    description,
+  title,
+  description,
 };
 ---
 
 <MainLayout content={meta} class="absolute">
   <div class="grid h-full content-center justify-center">
     <h1
-      class="prose relative z-10 bg-black text-9xl font-bold text-white mix-blend-difference"
+      class="prose relative z-10 bg-black text-[9rem] font-bold text-white mix-blend-difference"
       id="sofia"
     >
       {t("home.name")}


### PR DESCRIPTION
- Changed the h1 font size from text-9xl to text-[9rem]
- Used explicit rem units instead of the predefined Tailwind scale
- Ensured consistent and precise sizing across different environments