### PR TITLE
fix(ui): increase canvas z-index for proper layering

### DIFF
--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -42,7 +42,7 @@ const { content } = Astro.props;
   </head>
   <body>
     <div
-      class="flex h-screen w-screen cursor-none auto-rows-auto flex-col bg-white font-sans dark:bg-black dark:text-white sm:min-h-max md:h-screen lg:h-screen"
+      class="flex h-screen w-screen cursor-none auto-rows-auto flex-col overflow-auto bg-white font-sans dark:bg-black dark:text-white sm:min-h-max md:h-screen lg:h-screen"
     >
       <Header homeLink={localizePath("/")} workLink={localizePath("/works")} />
       <ins

--- a/src/layouts/MainLayout.astro
+++ b/src/layouts/MainLayout.astro
@@ -42,7 +42,7 @@ const { content } = Astro.props;
   </head>
   <body>
     <div
-      class="flex h-screen w-screen cursor-none auto-rows-auto flex-col overflow-auto bg-white font-sans dark:bg-black dark:text-white sm:min-h-max md:h-screen lg:h-screen"
+      class="flex h-screen w-screen cursor-none auto-rows-auto flex-col overflow-auto bg-white font-mono dark:bg-black dark:text-white sm:min-h-max md:h-screen lg:h-screen"
     >
       <Header homeLink={localizePath("/")} workLink={localizePath("/works")} />
       <ins

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const meta = {
     </h1>
   </div>
   <canvas
-    class="absolute right-0 top-0 z-0 h-screen w-screen mix-blend-difference"
+    class="absolute right-0 top-0 z-10 h-screen w-screen mix-blend-difference"
     id="canvas"></canvas>
   <script>
     import "../scripts/Balls";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,7 +23,7 @@ const meta = {
     </h1>
   </div>
   <canvas
-    class="absolute right-0 top-0 z-10 h-screen w-screen mix-blend-difference"
+    class="absolute right-0 top-0 z-0 h-screen w-screen mix-blend-difference"
     id="canvas"></canvas>
   <script>
     import "../scripts/Balls";


### PR DESCRIPTION
Change the canvas element's z-index from 0 to 10 to ensure it
appears above other elements as intended. This fixes layering issues
where the canvas was being obscured by other page content.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #22 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #23 
<!-- GitButler Footer Boundary Bottom -->

